### PR TITLE
Update README with testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,19 @@ curl -X POST http://localhost:8000/scan/gcp \
 
 A successful response returns the scan ID and the number of findings. You can then query MongoDB for the stored scan results.
 
+## Testing
+
+Ensure the dependencies from `requirements.txt` are installed before running the tests:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the Django test suite with:
+
+```bash
+python manage.py test
+```
+
+You may also configure `pytest` together with `pytest-django` if you prefer using `pytest` as the test runner.
+


### PR DESCRIPTION
## Summary
- document how to run tests via `python manage.py test`
- note the need to install requirements first
- mention pytest-django as an option

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6878da1164cc83299fdcc6d21096796f