### PR TITLE
Clarify AWS flags, add GCP projectId handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,13 @@ Two endpoints are provided once the server is running:
 - `POST /scan/aws` – trigger an AWS scan
 - `POST /scan/gcp` – trigger a GCP scan
 
-Both endpoints accept optional `checks` or `group` parameters which are passed
-to Prowler as `-c` or `-g` flags. This lets you run a subset of checks for
-faster scans. The GCP endpoint also supports an optional `projectId` parameter
-that is forwarded to Prowler as `--project-ids` to scan a specific project. You
-can also set the `GCP_PROJECT_ID` environment variable instead of passing it in
-the request.
+Both endpoints accept an optional `checks` parameter which is passed to Prowler
+with `-c` to run only the specified checks. The `group` flag (`-g`) is only
+supported for GCP scans&mdash;Prowler v3+ does not allow groups when scanning
+AWS. The GCP endpoint also supports an optional `projectId` parameter that is
+forwarded to Prowler as `--project-ids` to scan a specific project. You can also
+set the `GCP_PROJECT_ID` environment variable instead of passing it in the
+request.
 
 ### Example: AWS scan
 

--- a/cloudscan/prowler_runner.py
+++ b/cloudscan/prowler_runner.py
@@ -5,7 +5,7 @@ import time
 OUTPUT_DIR = os.path.abspath("./output")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
-def run_prowler_aws(access_key, secret_key, region, checks=None, group=None):
+def run_prowler_aws(access_key, secret_key, region, checks=None):
     timestamp = int(time.time() * 1000)
     output_filename = f"aws-scan-{timestamp}"
     output_json = os.path.join(OUTPUT_DIR, f"{output_filename}.asff.json")
@@ -26,8 +26,6 @@ def run_prowler_aws(access_key, secret_key, region, checks=None, group=None):
         prowler_cmd += ["--region", region]
     if checks:
         prowler_cmd += ["-c", checks]
-    if group:
-        prowler_cmd += ["-g", group]
 
     # You can print the command for debugging
     print("Running:", " ".join(prowler_cmd))
@@ -41,7 +39,7 @@ def run_prowler_aws(access_key, secret_key, region, checks=None, group=None):
         raise Exception("Prowler did not generate JSON output.")
     return output_json
 
-def run_prowler_gcp(gcp_key_file, checks=None, group=None, project_id=None):
+def run_prowler_gcp(gcp_key_file, project_id=None, checks=None, group=None):
     timestamp = int(time.time() * 1000)
     output_filename = f"gcp-scan-{timestamp}"
     output_csv = os.path.join(OUTPUT_DIR, f"{output_filename}.csv")

--- a/cloudscan/tests.py
+++ b/cloudscan/tests.py
@@ -83,8 +83,8 @@ class ScanViewTests(TestCase):
         self.assertEqual(scan.accountId, "gcp123")
         self.assertEqual(scan.projectId, "proj")
 
-    def test_scan_aws_with_checks_and_group(self):
-        """POST /scan/aws should pass checks and group to the runner."""
+    def test_scan_aws_with_checks(self):
+        """POST /scan/aws should pass checks to the runner."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp_json:
             json.dump([{"AwsAccountId": "123"}], tmp_json)
             json_path = tmp_json.name
@@ -96,14 +96,13 @@ class ScanViewTests(TestCase):
                     "accessKey": "AKIA...",
                     "secretKey": "secret",
                     "checks": "check1",
-                    "group": "group1",
                 },
             )
 
         os.remove(json_path)
 
         self.assertEqual(resp.status_code, 200)
-        mock_run.assert_called_with("AKIA...", "secret", "all", checks="check1", group="group1")
+        mock_run.assert_called_with("AKIA...", "secret", "all", checks="check1")
 
     def test_scan_gcp_with_checks_and_group(self):
         """POST /scan/gcp should pass checks and group to the runner."""

--- a/cloudscan/views.py
+++ b/cloudscan/views.py
@@ -5,7 +5,6 @@ from rest_framework import status
 from .prowler_runner import run_prowler_aws, run_prowler_gcp
 from .models import AWSScan, GCPScan
 from datetime import datetime
-from mongoengine import connect
 import csv
 import os
 
@@ -16,11 +15,10 @@ class ScanAWS(APIView):
         secret_key = os.getenv("AWS_SECRET_ACCESS_KEY") or request.data.get("secretKey")
         region = request.data.get("region", "all")
         checks = request.data.get("checks")
-        group = request.data.get("group")
         if not access_key or not secret_key:
             return Response({"error": "Missing AWS credentials"}, status=400)
         try:
-            json_path = run_prowler_aws(access_key, secret_key, region, checks=checks, group=group)
+            json_path = run_prowler_aws(access_key, secret_key, region, checks=checks)
             with open(json_path) as f:
                 findings = json.load(f)
             scan = AWSScan(
@@ -40,7 +38,7 @@ import tempfile
 class ScanGCP(APIView):
     def post(self, request):
         gcp_key_path = os.getenv("GCP_SERVICE_ACCOUNT_JSON_PATH")
-        project_id = os.getenv("GCP_PROJECT_ID") or request.data.get("projectId")
+        project_id = request.data.get("projectId") or os.getenv("GCP_PROJECT_ID")
         checks = request.data.get("checks")
         group = request.data.get("group")
         if not gcp_key_path:


### PR DESCRIPTION
## Summary
- document that Prowler's group flag is not supported for AWS
- allow request `projectId` to override env var for GCP scans
- drop `group` option from AWS scans
- expose projectId param in the runner
- update tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6878d884911083299c58e4d99f9959d1