### PR TITLE
Enable CORS for React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ CloudScan is a lightweight Django REST API that wraps [Prowler](https://github.c
    python manage.py runserver 0.0.0.0:8000
    ```
 
+### Running the React frontend
+
+1. Install dependencies and start the Vite dev server:
+
+   ```bash
+   cd frontend
+   npm install
+   cp .env.example .env  # sets VITE_API_BASE_URL
+   npm run dev
+   ```
+
+The API enables CORS so requests from the dev server (typically
+`http://localhost:5173`) can reach Django.
+
 ## Usage
 
 Two endpoints are provided once the server is running:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000

--- a/prow/settings.py
+++ b/prow/settings.py
@@ -26,12 +26,14 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "corsheaders",
     "cloudscan",
     # your custom apps here (like 'scans', etc)
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",      # << REQUIRED
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -70,3 +72,6 @@ DATABASES = {
 MONGODB_URI = os.getenv("MONGODB_URI")
 
 STATIC_URL = '/static/'
+
+# Allow cross-origin requests from the React dev server
+CORS_ALLOW_ALL_ORIGINS = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pymongo>=4.6.3
 mongoengine>=0.28.2
 python-dotenv>=1.0.1
 mongomock>=4.1.2
+django-cors-headers>=4.3


### PR DESCRIPTION
## Summary
- allow CORS so the React dev server can call the API
- document how to run the React frontend
- provide env template for frontend

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6878f095562c8329a15854522563aa0b