### PR TITLE
Update React API calls for Django backend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
+# URL where the Django backend is running
 VITE_API_BASE_URL=http://localhost:8000

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+});
+
+export default api;

--- a/frontend/src/pages/FindingDetails.jsx
+++ b/frontend/src/pages/FindingDetails.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
 import { useParams } from 'react-router-dom';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from '../api';
 
 const getSeverityColor = (severity) => {
   switch (severity?.toUpperCase()) {
@@ -37,7 +36,7 @@ const FindingDetails = () => {
   useEffect(() => {
     const fetchFinding = async () => {
       try {
-        const res = await axios.get(`${API_BASE_URL}/AWSfinding/${id}`);
+        const res = await api.get(`/AWSfinding/${id}`);
         setFindings(res.data.findings);
       } catch (err) {
         console.error('❌ Error fetching finding:', err);

--- a/frontend/src/pages/GCPFindingDetails.jsx
+++ b/frontend/src/pages/GCPFindingDetails.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
 import { useParams } from 'react-router-dom';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from '../api';
 
 const getSeverityColor = (severity) => {
   switch (severity?.toUpperCase()) {
@@ -37,7 +36,7 @@ const GCPFindingDetails = () => {
   useEffect(() => {
     const fetchFinding = async () => {
       try {
-        const res = await axios.get(`${API_BASE_URL}/GCPfinding/${id}`);
+        const res = await api.get(`/GCPfinding/${id}`);
         setFindings(res.data.findings);
       } catch (err) {
         console.error('❌ Error fetching finding:', err);

--- a/frontend/src/pages/GCPScanHistory.jsx
+++ b/frontend/src/pages/GCPScanHistory.jsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from '../api';
 
 const GCPScanHistory = () => {
     const [scans, setScans] = useState([]);
@@ -13,10 +12,13 @@ const GCPScanHistory = () => {
     useEffect(() => {
         const fetchScans = async () => {
             try {
-                const res = await axios.get(`${API_BASE_URL}/GCPscanlist`);
+                const res = await api.get('/GCPscanlist');
                 setScans(res.data.data);
             } catch (err) {
-                console.error('❌ Error fetching scan list:', err);
+                console.error(
+                    '❌ Error fetching scan list:',
+                    err.response?.data?.error || err
+                );
             } finally {
                 setLoading(false);
             }
@@ -31,7 +33,7 @@ const GCPScanHistory = () => {
 
     const handleDownloadSelected = async (selectedIds) => {
         try {
-            const res = await axios.post(`${API_BASE_URL}/gcp-xls`, {
+            const res = await api.post('/gcp-xls', {
                 id: selectedIds,
             });
            
@@ -63,7 +65,10 @@ const GCPScanHistory = () => {
             const blob = new Blob([excelBuffer], { type: "application/octet-stream" });
             saveAs(blob, `GCP_scan_${selectedIds}_findings.xlsx`);
         } catch (err) {
-            console.error("❌ Error downloading Excel:", err);
+            console.error(
+                "❌ Error downloading Excel:",
+                err.response?.data?.error || err
+            );
         }
     }
 

--- a/frontend/src/pages/GCPScanList.jsx
+++ b/frontend/src/pages/GCPScanList.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react"
-import axios from "axios"
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from "../api"
 const GCPScanList = () => {
   const [scans, setScans] = useState([])
   const [loading, setLoading] = useState(true)
@@ -8,11 +7,14 @@ const GCPScanList = () => {
   useEffect(() => {
     const fetchScanData = async () => {
       try {
-        const res = await axios.get(`${API_BASE_URL}/GCP_Scan`)
+        const res = await api.get('/GCP_Scan')
         setScans(res.data.findings)
         console.table(res.data.findings)
       } catch (err) {
-        console.error("Failed to fetch scan list:", err)
+        console.error(
+          "Failed to fetch scan list:",
+          err.response?.data?.error || err
+        )
       } finally {
         setLoading(false)
       }

--- a/frontend/src/pages/Scan.jsx
+++ b/frontend/src/pages/Scan.jsx
@@ -1,14 +1,12 @@
 import React, { useState } from 'react';
-import axios from 'axios';
 import { Cloud, ShieldCheck, UploadCloud } from 'lucide-react';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from '../api';
 const Scan = () => {
   const [provider, setProvider] = useState('');
   const [awsCreds, setAwsCreds] = useState({ accessKey: '', secretKey: '', region: 'all' });
   const [gcpKeyFile, setGcpKeyFile] = useState(null);
   const [loading, setLoading] = useState(false);
   const [response, setResponse] = useState('');
-  console.log(API_BASE_URL)
 
   const handleAwsChange = (e) => {
     setAwsCreds({ ...awsCreds, [e.target.name]: e.target.value });
@@ -24,18 +22,18 @@ const Scan = () => {
 
     try {
       if (provider === 'AWS') {
-        const res = await axios.post(`${API_BASE_URL}/scan/aws`, awsCreds);
+        const res = await api.post('/scan/aws', awsCreds);
         setResponse(JSON.stringify(res.data, null, 2));
       } else if (provider === 'GCP') {
         const formData = new FormData();
         formData.append('keyFile', gcpKeyFile);
-        const res = await axios.post(`${API_BASE_URL}/scan/gcp`, formData, {
+        const res = await api.post('/scan/gcp', formData, {
           headers: { 'Content-Type': 'multipart/form-data' }
         });
         setResponse(JSON.stringify(res.data, null, 2));
       }
     } catch (err) {
-      setResponse(`❌ Error: ${err.message}`);
+      setResponse(`❌ Error: ${err.response?.data?.error || err.message}`);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/ScanHistory.jsx
+++ b/frontend/src/pages/ScanHistory.jsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
 import * as XLSX from 'xlsx';
 import { saveAs } from 'file-saver';
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from '../api';
 
 const ScanHistory = () => {
     const [scans, setScans] = useState([]);
@@ -13,10 +12,13 @@ const ScanHistory = () => {
     useEffect(() => {
         const fetchScans = async () => {
             try {
-                const res = await axios.get(`${API_BASE_URL}/scanlist`);
+                const res = await api.get('/scanlist');
                 setScans(res.data.data);
             } catch (err) {
-                console.error('❌ Error fetching scan list:', err);
+                console.error(
+                    '❌ Error fetching scan list:',
+                    err.response?.data?.error || err
+                );
             } finally {
                 setLoading(false);
             }
@@ -31,7 +33,7 @@ const ScanHistory = () => {
 
     const handleDownloadSelected = async (selectedIds) => {
         try {
-            const res = await axios.post(`${API_BASE_URL}/xls`, {
+            const res = await api.post('/xls', {
                 id: selectedIds,
             });
            
@@ -63,7 +65,10 @@ const ScanHistory = () => {
             const blob = new Blob([excelBuffer], { type: "application/octet-stream" });
             saveAs(blob, `scan_${selectedIds}_findings.xlsx`);
         } catch (err) {
-            console.error("❌ Error downloading Excel:", err);
+            console.error(
+                "❌ Error downloading Excel:",
+                err.response?.data?.error || err
+            );
         }
     }
 

--- a/frontend/src/pages/ScanList.jsx
+++ b/frontend/src/pages/ScanList.jsx
@@ -1,8 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import axios from "axios"
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import api from "../api"
 const ScanList = () => {
   const [scans, setScans] = useState([])
   const [loading, setLoading] = useState(true)
@@ -10,11 +9,14 @@ const ScanList = () => {
   useEffect(() => {
     const fetchScanData = async () => {
       try {
-        const res = await axios.get(`${API_BASE_URL}/AWS_Scan`)
+        const res = await api.get('/AWS_Scan')
         setScans(res.data.findings)
         console.table(res.data.findings)
       } catch (err) {
-        console.error("Failed to fetch scan list:", err)
+        console.error(
+          "Failed to fetch scan list:",
+          err.response?.data?.error || err
+        )
       } finally {
         setLoading(false)
       }


### PR DESCRIPTION
## Summary
- centralize API access via new `api.js`
- update all React pages to use the Django endpoints through the API helper
- adjust error handling for Django REST error messages
- document backend URL in frontend `.env.example`

## Testing
- `python manage.py test`
- `npm run lint` *(fails: cannot satisfy lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_6878f683e7e88329905a5457c684cab5