### PR TITLE
Fix API base URL and add Vite proxy

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: BASE_URL,
 });
 
 export default api;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,22 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const BACKEND = 'http://localhost:8000'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/scan': BACKEND,
+      '/AWSfinding': BACKEND,
+      '/GCPfinding': BACKEND,
+      '/AWS_Scan': BACKEND,
+      '/GCP_Scan': BACKEND,
+      '/scanlist': BACKEND,
+      '/GCPscanlist': BACKEND,
+      '/xls': BACKEND,
+      '/gcp-xls': BACKEND,
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- default API base URL to Django port
- add dev server proxy rules to forward to Django backend

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6878fd590b848329b937ad80daa56322