### PR TITLE
Fix trailing slash for GCP scan endpoint

### DIFF
--- a/cloudscan/urls.py
+++ b/cloudscan/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 from .views import (
     ScanAWS,
-    ScanGCP,
+    scan_gcp,
     LatestAWSFindings,
     LatestGCPFindings,
     AWSFinding,
@@ -15,7 +15,9 @@ from cloudscan import views
 
 urlpatterns = [
     path('scan/aws', ScanAWS.as_view(), name='scan-aws'),
-    path('scan/gcp', ScanGCP.as_view(), name='scan-gcp'),
+    # accept both with and without trailing slash
+    path('scan/gcp', scan_gcp, name='scan-gcp'),
+    path('scan/gcp/', scan_gcp, name='scan-gcp-slash'),
     path('AWS_Scan', LatestAWSFindings.as_view(), name='aws-latest'),
     path('GCP_Scan', LatestGCPFindings.as_view(), name='gcp-latest'),
     path('AWSfinding/<str:scan_id>', AWSFinding.as_view(), name='aws-finding'),

--- a/frontend/src/pages/Scan.jsx
+++ b/frontend/src/pages/Scan.jsx
@@ -27,7 +27,7 @@ const Scan = () => {
       } else if (provider === 'GCP') {
         const formData = new FormData();
         formData.append('keyFile', gcpKeyFile);
-        const res = await api.post('/scan/gcp', formData, {
+        const res = await api.post('/scan/gcp/', formData, {
           headers: { 'Content-Type': 'multipart/form-data' }
         });
         setResponse(JSON.stringify(res.data, null, 2));


### PR DESCRIPTION
## Summary
- add dedicated `scan_gcp` function view returning `JsonResponse`
- expose `/scan/gcp/` URL and map both versions of the path
- update frontend API call to use `/scan/gcp/`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68790281dd2c832985674ad40adc0694