### PR TITLE
Enable project selection for GCP scans

### DIFF
--- a/cloudscan/urls.py
+++ b/cloudscan/urls.py
@@ -15,6 +15,7 @@ from .views import (
     GCPScanHistory,
     AWSScanFindingsExcel,
     GCPScanFindingsExcel,
+    upload_gcp_key,
     home,
 )
 
@@ -23,6 +24,7 @@ urlpatterns = [
     path('scan/aws', ScanAWS.as_view(), name='scan-aws'),
     path('scan/gcp', scan_gcp, name='scan-gcp'),
     path('scan/gcp/', scan_gcp, name='scan-gcp-slash'),  # with trailing slash
+    path('gcp/projects', upload_gcp_key, name='gcp-projects'),
 
     # Prowler Scan APIs
     path('scan/gcp/', prowler_scan_gcp, name='prowler-scan-gcp'),  # For POST scan trigger

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mongoengine>=0.28.2
 python-dotenv>=1.0.1
 mongomock>=4.1.2
 django-cors-headers>=4.3
+google-cloud-resource-manager>=1.14


### PR DESCRIPTION
## Summary
- support Google Cloud project discovery
- keep uploaded service account files and use them by `keyId`
- add async scan runner for GCP projects
- expose `/api/prowler/gcp/projects` to return accessible projects
- update React UI to upload key, fetch projects and start scan
- expand tests for new endpoints

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6879298e76108329b1a42892fe120008