### PR TITLE
Show toast when GCP Resource Manager API is disabled

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.3",
+        "react-toastify": "^11.0.5",
         "xlsx": "^0.18.5"
       },
       "devDependencies": {
@@ -2401,6 +2402,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/codepage": {
@@ -5495,6 +5505,19 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3",
+    "react-toastify": "^11.0.5",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import "./index.css"
 import "./App.css"
 import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import Scan from './pages/Scan';
 import ScanList from './pages/ScanList';
 import Nav from './component/Nav';
@@ -13,6 +15,7 @@ import GCPFindingDetails from './pages/GCPFindingDetails';
 function App() {
   return (
 <BrowserRouter>
+  <ToastContainer position="top-center" />
   <div className="flex h-screen w-screen">
 
     <div className="w-64 bg-gray-800 text-white">

--- a/frontend/src/pages/Scan.jsx
+++ b/frontend/src/pages/Scan.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Cloud, ShieldCheck, UploadCloud } from 'lucide-react';
+import { toast } from 'react-toastify';
 import api from '../api';
 const Scan = () => {
   const [provider, setProvider] = useState('');
@@ -99,7 +100,26 @@ const handleScan = async () => {
       }
     } catch (err) {
       setLoading(false);
-      setResponse(`❌ Error: ${err.response?.data?.error || err.message}`);
+      const errorMsg = err.response?.data?.error || err.message;
+      setResponse(`❌ Error: ${errorMsg}`);
+      if (errorMsg && errorMsg.includes('Cloud Resource Manager API')) {
+        toast.error(
+          <div>
+            Cloud Resource Manager API is not enabled for this project.{' '}
+            <a
+              href={`https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=${selectedProject}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              Enable API
+            </a>
+          </div>,
+          { autoClose: false }
+        );
+      } else {
+        toast.error(errorMsg);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- install `react-toastify`
- add global toast container in `App.jsx`
- show toast with link when GCP scan returns error for Cloud Resource Manager API

## Testing
- `python manage.py test -v 2`
- `npm run lint` *(fails: 18 errors)*


------
https://chatgpt.com/codex/tasks/task_e_6879e33e0908832984af4632d4be05a6