### PR TITLE
Improve error toast when listing GCP projects

### DIFF
--- a/frontend/src/pages/Scan.jsx
+++ b/frontend/src/pages/Scan.jsx
@@ -49,7 +49,24 @@ const handleGcpFileChange = async (e) => {
     setGcpProjects(res.data.projects);
     setKeyId(res.data.keyId);
   } catch (err) {
-    setResponse(`❌ Error: ${err.response?.data?.error || err.message}`);
+    const errorMsg = err.response?.data?.error || err.message;
+    setResponse(`❌ Error: ${errorMsg}`);
+    if (errorMsg && errorMsg.includes('Cloud Resource Manager API')) {
+      toast.error(
+        <div>
+          Cloud Resource Manager API is not enabled for this project.{' '}
+          <a
+            href="https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Enable API
+          </a>
+        </div>,
+        { autoClose: false }
+      );
+    }
   } finally {
     setFetchingProjects(false);
   }


### PR DESCRIPTION
## Summary
- show a toast with a link to enable the Cloud Resource Manager API when uploading a GCP key fails

## Testing
- `npm run lint` *(fails: 18 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879e5e3783c8329b8018d5bc0b026dc