### PR TITLE
Allow manual GCP project input

### DIFF
--- a/cloudscan/tests.py
+++ b/cloudscan/tests.py
@@ -218,6 +218,17 @@ class ScanViewTests(TestCase):
         self.assertEqual(data["projects"], ["proj1", "proj2"])
         self.assertIn("keyId", data)
 
+    def test_upload_gcp_key_handles_project_list_error(self):
+        """Even if listing projects fails, a keyId should be returned."""
+        uploaded = SimpleUploadedFile("key.json", b"{}", content_type="application/json")
+        with patch("cloudscan.views.fetch_project_ids", side_effect=Exception("bad")):
+            resp = self.client.post("/api/prowler/gcp/projects", {"keyFile": uploaded})
+
+        self.assertEqual(resp.status_code, 200)
+        data = json.loads(resp.content)
+        self.assertEqual(data["projects"], [])
+        self.assertIn("keyId", data)
+
     def test_scan_gcp_with_key_id(self):
         """/scan/gcp should accept keyId referencing uploaded file."""
         uploaded = SimpleUploadedFile("key.json", b"{}", content_type="application/json")

--- a/cloudscan/views.py
+++ b/cloudscan/views.py
@@ -123,9 +123,11 @@ def upload_gcp_key(request):
 
     try:
         projects = fetch_project_ids(key_path)
-    except Exception as e:
-        os.remove(key_path)
-        return JsonResponse({"error": str(e)}, status=500)
+    except Exception:
+        # If the Cloud Resource Manager API is disabled or the key lacks
+        # permissions, listing projects will fail. Still return a keyId so the
+        # user can manually provide a project ID for scanning.
+        projects = []
 
     key_id = str(uuid4())
     TEMP_KEYS[key_id] = key_path

--- a/frontend/src/pages/Scan.jsx
+++ b/frontend/src/pages/Scan.jsx
@@ -50,11 +50,11 @@ const handleGcpFileChange = async (e) => {
     setKeyId(res.data.keyId);
   } catch (err) {
     const errorMsg = err.response?.data?.error || err.message;
-    setResponse(`❌ Error: ${errorMsg}`);
     if (errorMsg && errorMsg.includes('Cloud Resource Manager API')) {
+      setResponse('');
       toast.error(
         <div>
-          Cloud Resource Manager API is not enabled for this project.{' '}
+          Cloud Resource Manager API is not enabled for this project.{" "}
           <a
             href="https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com"
             target="_blank"
@@ -66,6 +66,8 @@ const handleGcpFileChange = async (e) => {
         </div>,
         { autoClose: false }
       );
+    } else {
+      setResponse(`❌ Error: ${errorMsg}`);
     }
   } finally {
     setFetchingProjects(false);
@@ -118,11 +120,11 @@ const handleScan = async () => {
     } catch (err) {
       setLoading(false);
       const errorMsg = err.response?.data?.error || err.message;
-      setResponse(`❌ Error: ${errorMsg}`);
       if (errorMsg && errorMsg.includes('Cloud Resource Manager API')) {
+        setResponse('');
         toast.error(
           <div>
-            Cloud Resource Manager API is not enabled for this project.{' '}
+            Cloud Resource Manager API is not enabled for this project.{" "}
             <a
               href={`https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=${selectedProject}`}
               target="_blank"
@@ -135,6 +137,7 @@ const handleScan = async () => {
           { autoClose: false }
         );
       } else {
+        setResponse(`❌ Error: ${errorMsg}`);
         toast.error(errorMsg);
       }
     }
@@ -226,7 +229,7 @@ const handleScan = async () => {
             <input type="file" className="hidden" accept=".json" onChange={handleGcpFileChange} />
           </label>
           {fetchingProjects && <p className="text-sm text-blue-600">Loading projects...</p>}
-          {gcpProjects.length > 0 && !fetchingProjects && (
+          {gcpProjects.length > 0 && !fetchingProjects ? (
             <select
               className="w-full border border-gray-300 px-4 py-2 rounded-lg"
               value={selectedProject}
@@ -237,6 +240,16 @@ const handleScan = async () => {
                 <option key={p} value={p}>{p}</option>
               ))}
             </select>
+          ) : (
+            keyId && !fetchingProjects && (
+              <input
+                type="text"
+                className="w-full border border-gray-300 px-4 py-2 rounded-lg"
+                placeholder="Enter GCP project ID"
+                value={selectedProject}
+                onChange={(e) => setSelectedProject(e.target.value)}
+              />
+            )
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- allow uploading a GCP key even when project listing fails
- let users manually enter GCP project ID in the React UI
- avoid showing Cloud Resource Manager error text in output
- test upload_gcp_key when listing projects fails

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6879eae68f288329948a1eadcb510859