### PR TITLE
Fix GCP project listing feedback

### DIFF
--- a/cloudscan/tests.py
+++ b/cloudscan/tests.py
@@ -217,6 +217,7 @@ class ScanViewTests(TestCase):
         data = json.loads(resp.content)
         self.assertEqual(data["projects"], ["proj1", "proj2"])
         self.assertIn("keyId", data)
+        self.assertNotIn("warning", data)
 
     def test_upload_gcp_key_handles_project_list_error(self):
         """Even if listing projects fails, a keyId should be returned."""
@@ -228,6 +229,7 @@ class ScanViewTests(TestCase):
         data = json.loads(resp.content)
         self.assertEqual(data["projects"], [])
         self.assertIn("keyId", data)
+        self.assertEqual(data.get("warning"), "bad")
 
     def test_scan_gcp_with_key_id(self):
         """/scan/gcp should accept keyId referencing uploaded file."""

--- a/cloudscan/views.py
+++ b/cloudscan/views.py
@@ -123,15 +123,22 @@ def upload_gcp_key(request):
 
     try:
         projects = fetch_project_ids(key_path)
-    except Exception:
+    except Exception as exc:  # pylint: disable=broad-except
         # If the Cloud Resource Manager API is disabled or the key lacks
         # permissions, listing projects will fail. Still return a keyId so the
-        # user can manually provide a project ID for scanning.
+        # user can manually provide a project ID for scanning. Also return a
+        # warning message so the frontend can surface the issue.
         projects = []
+        warning = str(exc)
+    else:
+        warning = None
 
     key_id = str(uuid4())
     TEMP_KEYS[key_id] = key_path
-    return JsonResponse({"projects": projects, "keyId": key_id})
+    response = {"projects": projects, "keyId": key_id}
+    if warning:
+        response["warning"] = warning
+    return JsonResponse(response)
         
 
 


### PR DESCRIPTION
## Summary
- add `warning` message to `/gcp/projects` endpoint when listing projects fails
- test the new behaviour

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687a1f5b1a3c83299aacee93c959f4f9